### PR TITLE
fix(quote): Make `guaranteedUntil` field optional

### DIFF
--- a/fiatconnect-api.md
+++ b/fiatconnect-api.md
@@ -702,7 +702,7 @@ On success, the server MUST return an HTTP `200`, with the following response bo
 		cryptoType: `CryptoTypeEnum`,
 		fiatAmount: `float`,
 		cryptoAmount: `float`,
-		guaranteedUntil: `string`
+		guaranteedUntil?: `string`
 	},
 	kyc: {
 		kycRequired: `boolean`,


### PR DESCRIPTION
The `guaranteedUntil` field in the `GET /quote/out` endpoint response should have been optional.