### PR TITLE
Rework Authentication scheme, require SIWE, remove JWT

### DIFF
--- a/fiatconnect-api.md
+++ b/fiatconnect-api.md
@@ -224,6 +224,7 @@
     + [8.1.5. [EIP-55]](#815--eip-55-)
     + [8.1.6. [EIP-191]](#816--eip-191-)
     + [8.1.7. [EIP-1271]](#817--eip-1271-)
+    + [8.1.8. [EIP-2098]](#818--eip-2098-)
   * [8.2. Informative References](#82-informative-references)
     + [8.2.1. Webhook Best Practices](#821-webhook-best-practices)
     + [8.2.2. Idempotency Keys](#822-idempotency-keys)
@@ -2008,6 +2009,10 @@ EIP-191: Signed Data Standard, <https://eips.ethereum.org/EIPS/eip-191>
 ### 8.1.7. [EIP-1271]
 
 EIP-1271: Standard Signature Validation Method for Contracts, <https://eips.ethereum.org/EIPS/eip-1271>
+
+### 8.1.8. [EIP-2098]
+
+EIP-2098: Compact Signature Representation, <https://eips.ethereum.org/EIPS/eip-2098>
 
 ## 8.2. Informative References
 

--- a/fiatconnect-api.md
+++ b/fiatconnect-api.md
@@ -33,6 +33,7 @@
 		    - [3.2.1.5.3.2.1. `InvalidSignature`](#3215321--invalidsignature-)
 		    - [3.2.1.5.3.2.2. `InvalidParameters`](#3215322--invalidparameters-)
 		    - [3.2.1.5.3.2.3. `ContractLoginNotSupported`](#3215323--contractloginnotsupported-)
+		    - [3.2.1.5.3.2.4. `NonceInUse`](#3215324--nonceinuse-)
 	  - [3.2.1.6. Using Sessions](#3216-using-sessions)
 	    * [3.2.1.6.1. Non-Privileged Endpoints](#32161-non-privileged-endpoints)
 	    * [3.2.1.6.2. Privileged Endpoints](#32162-privileged-endpoints)
@@ -558,21 +559,25 @@ sure that nonce management works correctly when scaling server resources.
 
 On failure, the server MUST return an HTTP `401` error, along with an error code that details exactly why the request failed.
 
-###### 3.2.1.5.3.2.1 `InvalidSignature`
+###### 3.2.1.5.3.2.1. `InvalidSignature`
 
 If the signature is invalid or doesn't match the included `address` field, the server MUST return an `InvalidSignature` error. Note that the address used
 to sign the message may not actually match the address being authenticated in the case where the client is authenticating as a contract-owned account. In
 such cases, `InvalidSignature` MUST NOT be returned when the signature is valid, and the address used to sign the message is considered valid by the contract
 referenced in the `address` field.
 
-###### 3.2.1.5.3.2.2 `InvalidParameters`
+###### 3.2.1.5.3.2.2. `InvalidParameters`
 
 If the request body is missing, malformed, or fails to pass any of the required checks, the server MUST respond with an `InvalidParameters` error.
 
-###### 3.2.1.5.3.2.3 `ContractLoginNotSupported`
+###### 3.2.1.5.3.2.3. `ContractLoginNotSupported`
 
 If the server determines that a client is trying to log in as a contrract-owned account but the server does not support contract-owned account logins, the
 server MUST respond with a `ContractLoginNotSupported` error.
+
+###### 3.2.1.5.3.2.4. `NonceInUse`
+
+If the nonce included in the message is already attached to a valid session, the server MUST respond with a `NonceInUse` error.
 
 #### 3.2.1.6. Using Sessions
 
@@ -1779,7 +1784,8 @@ An enum listing the error types used by various endpoints.
 	`SessionExpired`,
 	`SessionTooOld`,
 	`InvalidParameters`,
-	`ContractLoginNotSupported`
+	`ContractLoginNotSupported`,
+	`NonceInUse`
 ]
 ```
 

--- a/fiatconnect-api.md
+++ b/fiatconnect-api.md
@@ -555,6 +555,10 @@ greater than two weeks (1209600 seconds) ahead of the `issued-at` field, the ser
 is formatted correctly, the server MUST authenticate the user's session, and return an HTTP `200`. The server MUST attach the fields from the signed message to the session internally,
 in order to access data about the user and their session in other endpoints.
 
+Once a server authenticates a session using a particular nonce, the server MUST NOT allow any other sessions to be created using that nonce, until `expiration-time` of the session created
+using that nonce has been reached. The implementation of this is up to the server, but will require storing some global state about nonces in order to check if a client is attempting
+to sign-in using a nonce that is temporarily forbidden. Careful consideration should be taken to make sure that nonce management works correctly when scaling server resources.
+
 ###### 3.2.1.3.3.2. Failure
 
 On failure, the server MUST return an HTTP `401` error, along with an error code that details exactly why the request failed.

--- a/fiatconnect-api.md
+++ b/fiatconnect-api.md
@@ -493,13 +493,14 @@ The request body must contain the following fields:
 
 * `message`: {`string`} [REQUIRED]
   - The plaintext SIWE message
-* `signature`: {`object`} [REQUIRED]
+* `signature`: {`string`} [REQUIRED]
   - The [EIP-191](https://eips.ethereum.org/EIPS/eip-191) signed message if logging in as EOA, or a signature according to the
 	[EIP-1271](https://eips.ethereum.org/EIPS/eip-1271) standard, if logging in as a contract-owned account.
 
-The `message` field should be the *plaintext* message, while the signature should be an object containing the typical secp256k1 signature fields: `r`, `s`, and `v`.
-`r` and `s` are hex strings (prefixed with `0x`) each 32 bytes in length, and `v` is an integer. This is the "canonical" form of the signature as referenced in
-[EIP-2098](https://eips.ethereum.org/EIPS/eip-2098), rather than the "compact" form.
+The `message` field should be the *plaintext* message, while the signature should be an string containing the typical secp256k1 signature fields: `r`, `s`, and `v`.
+This `signature` string should be a hex string, prefixed with `0x`. The hex data should be 65 bytes long (130 hex characters, *excluding* the leading `0x`). The first
+32 bytes (64 hex characters) represent `r`, the next 32 bytes (64 hex characters) represent `s`, and the final byte (2 hex characters) represent `v`. This is the "canonical"
+form of the signature as referenced in [EIP-2098](https://eips.ethereum.org/EIPS/eip-2098), rather than the "compact" form.
 
 ##### 3.2.1.5.2. Responses
 
@@ -575,7 +576,7 @@ error type is more descriptive of the actual issue, that error should be used in
 
 ###### 3.2.1.5.3.2.3. `ContractLoginNotSupported`
 
-If the server determines that a client is trying to log in as a contrract-owned account but the server does not support contract-owned account logins, the
+If the server determines that a client is trying to log in as a contract-owned account but the server does not support contract-owned account logins, the
 server MUST respond with a `ContractLoginNotSupported` error.
 
 ###### 3.2.1.5.3.2.4. `NonceInUse`

--- a/fiatconnect-api.md
+++ b/fiatconnect-api.md
@@ -1782,7 +1782,6 @@ An enum listing the error types used by various endpoints.
 	`KycExpired`,
 	`Unauthorized`,
 	`SessionExpired`,
-	`SessionTooOld`,
 	`InvalidParameters`,
 	`ContractLoginNotSupported`,
 	`NonceInUse`

--- a/fiatconnect-api.md
+++ b/fiatconnect-api.md
@@ -490,11 +490,13 @@ The request body must contain the following fields:
 
 * `message`: {`string`} [REQUIRED]
   - The plaintext SIWE message
-* `signature`: {`string`} [REQUIRED]
+* `signature`: {`object`} [REQUIRED]
   - The [EIP-191](https://eips.ethereum.org/EIPS/eip-191) signed message if logging in as EOA, or a signature according to the
 	[EIP-1271](https://eips.ethereum.org/EIPS/eip-1271) standard, if logging in as a contract-owned account.
 
-Both fields should be encoded as base64 strings.
+The `message` field should be the *plaintext* message, while the signature should be an object containing the typical secp256k1 signature fields: `r`, `s`, and `v`.
+`r` and `s` are hex strings (prefixed with `0x`) each 32 bytes in length, and `v` is an integer. This is the "canonical" form of the signature as referenced in
+[EIP-2098](https://eips.ethereum.org/EIPS/eip-2098), rather than the "compact" form.
 
 ##### 3.2.1.5.2. Responses
 

--- a/fiatconnect-api.md
+++ b/fiatconnect-api.md
@@ -34,6 +34,8 @@
 		    - [3.2.1.5.3.2.2. `InvalidParameters`](#3215322--invalidparameters-)
 		    - [3.2.1.5.3.2.3. `ContractLoginNotSupported`](#3215323--contractloginnotsupported-)
 		    - [3.2.1.5.3.2.4. `NonceInUse`](#3215324--nonceinuse-)
+		    - [3.2.1.5.3.2.5. `IssuedTooEarly`](#3215325--issuedtooearly-)
+		    - [3.2.1.5.3.2.6. `ExpirationTooLong`](#3215326--expirationtoolong-)
 	  - [3.2.1.6. Using Sessions](#3216-using-sessions)
 	    * [3.2.1.6.1. Non-Privileged Endpoints](#32161-non-privileged-endpoints)
 	    * [3.2.1.6.2. Privileged Endpoints](#32162-privileged-endpoints)
@@ -568,7 +570,8 @@ referenced in the `address` field.
 
 ###### 3.2.1.5.3.2.2. `InvalidParameters`
 
-If the request body is missing, malformed, or fails to pass any of the required checks, the server MUST respond with an `InvalidParameters` error.
+If the request body is missing, malformed, or fails to pass any of the required checks, the server MUST respond with an `InvalidParameters` error. If another
+error type is more descriptive of the actual issue, that error should be used instead.
 
 ###### 3.2.1.5.3.2.3. `ContractLoginNotSupported`
 
@@ -578,6 +581,14 @@ server MUST respond with a `ContractLoginNotSupported` error.
 ###### 3.2.1.5.3.2.4. `NonceInUse`
 
 If the nonce included in the message is already attached to a valid session, the server MUST respond with a `NonceInUse` error.
+
+###### 3.2.1.5.3.2.5. `IssuedTooEarly`
+
+If the `issued-at` field is before the server's current timestamp, the server MUST respond with an `IssuedTooEarly` error.
+
+###### 3.2.1.5.3.2.6. `ExpirationTooLong`
+
+If ther `expiration-time` field is more than four hours into the future, the server MUST respond with an `ExpirationTooLong` error.
 
 #### 3.2.1.6. Using Sessions
 
@@ -1784,7 +1795,9 @@ An enum listing the error types used by various endpoints.
 	`SessionExpired`,
 	`InvalidParameters`,
 	`ContractLoginNotSupported`,
-	`NonceInUse`
+	`NonceInUse`,
+	`IssuedTooEarly`,
+	`ExpirationTooLong`
 ]
 ```
 


### PR DESCRIPTION
This PR drops support for the JWT auth scheme in favor of using the Sign-In With Ethereum standard.