### PR TITLE
specifying ISO 3166-1 alpha-2

### DIFF
--- a/fiatconnect-api.md
+++ b/fiatconnect-api.md
@@ -524,7 +524,7 @@ used for the transfer.
 * `cryptoAmount`: {`float`}
   - The amount of the selected crypto type to use for this transfer in quote; if provided, the returned quote will be denominated in the type of fiat specified for the quote.
 * `country`: {`string`} [REQUIRED]
-  - An ISO 3166-1 country code representing the country where the quote should be requested for.
+  - An ISO 3166-1 alpha-2 country code representing the country where the quote should be requested for.
 * `region`: {`string`}
   - An optional ISO 3166-2 subdivision code representing a region within the provided country.
 


### PR DESCRIPTION
there are several standards under ISO 3166-1, thought it would make sense to specify it as `ISO 3166-1 alpha-2` to avoid confusions 
https://en.wikipedia.org/wiki/ISO_3166-1