### PR TITLE
Add FiatType brazilian Real and cReal CryptoType

### DIFF
--- a/fiatconnect-api.md
+++ b/fiatconnect-api.md
@@ -1663,7 +1663,8 @@ An enum listing the types of fiat currencies supported by FiatConnect.
 ```
 [
 	`USD`,
-	`EUR`
+	`EUR`,
+  `BRL`
 ]
 ```
 
@@ -1675,6 +1676,7 @@ An enum listing the types of crypto tokens suppored by FiatConnect.
 [
 	`cUSD`,
 	`cEUR`,
+  `cREAL`,
 	`CELO`
 ]
 ```

--- a/fiatconnect-api.md
+++ b/fiatconnect-api.md
@@ -1664,7 +1664,7 @@ An enum listing the types of fiat currencies supported by FiatConnect.
 [
 	`USD`,
 	`EUR`,
-  `BRL`
+  `REAL`
 ]
 ```
 

--- a/fiatconnect-api.md
+++ b/fiatconnect-api.md
@@ -1568,7 +1568,7 @@ by webhook throughout the process, but verifications willalways end in approval.
 ## 6.4. Fiat Accounts
 
 Sandbox APIs MUST never internally connect to a provided Fiat Account or perform any sort of validation that user-submitted Fiat Account details are "valid".
-Sandbox APIs MUST never actually interact with a user's real fiat accounts.
+Sandbox APIs MUST never actually interact with a user's personal fiat accounts.
 
 ## 6.5. Transfers
 

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -426,11 +426,13 @@ definitions:
     enum:
       - USD
       - EUR
+      - REAL
   CryptoType:
     type: "string"
     enum:
       - cUSD
       - cEUR
+      - cREAL
       - CELO
   FeeType:
     type: "string"


### PR DESCRIPTION
Adding Brazilian currency Types [[reference](https://medium.com/celoorg/celo-launches-the-creal-stablecoin-11da0d560c1c)]
