### PR TITLE
fix: quote ids swagger

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -475,7 +475,9 @@ definitions:
             type: "number"
           cryptoAmount:
             type: "number"
-          guaranteedUntil?:
+          quoteId:
+            type: "string"
+          guaranteedUntil:
             type: "string"
       kyc:
         type: "object"

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -38,10 +38,7 @@ paths:
         "200":
           description: "successful operation"
           schema:
-            type: "object"
-            properties:
-              kycStatus:
-                $ref: '#/definitions/QuoteResponse'
+            $ref: '#/definitions/QuoteResponse'
         "400":
           description: "failed operation"
           schema:
@@ -70,10 +67,7 @@ paths:
         "200":
           description: "successful operation"
           schema:
-            type: "object"
-            properties:
-              kycStatus:
-                $ref: '#/definitions/QuoteResponse'
+            $ref: '#/definitions/QuoteResponse'
         "400":
           description: "failed operation"
           schema:

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -554,6 +554,8 @@ definitions:
         type: "number"
       fiatAccountId:
         type: "string"
+      quoteId:
+        type: "string"
   TransferResponse:
     type: "object"
     properties:
@@ -597,6 +599,7 @@ definitions:
     enum:
       - TransferNotAllowed
       - KycExpired
+      - InvalidQuote
   SchemaErrorEnum:
     type: "string"
     enum:


### PR DESCRIPTION
Updates to keep openapi spec in sync with markdown spec from changes in https://github.com/fiatconnect/specification/pull/19

added quoteId to quote response schema, and made guaranteedUntil required
<img width="574" alt="Screen Shot 2022-04-15 at 7 39 23 PM" src="https://user-images.githubusercontent.com/7979215/163603107-7df9967e-1952-47ea-8862-3a5733b97a94.png">

added quoteId to transfer request body
<img width="542" alt="Screen Shot 2022-04-15 at 7 38 35 PM" src="https://user-images.githubusercontent.com/7979215/163603117-f130a125-7553-4aeb-933a-dc0914dd2cc0.png">

added InvalidQuote error type
<img width="458" alt="Screen Shot 2022-04-15 at 7 38 52 PM" src="https://user-images.githubusercontent.com/7979215/163603116-20cdf5c3-a853-4dde-8f46-d42bc67d969e.png">
