### PR TITLE
fix: update openapi to be in sync with markdown spec

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -615,6 +615,7 @@ definitions:
       - FiatAmountTooHigh
       - CryptoNotSupported
       - FiatNotSupported
+      - InvalidParameters
   ResourceExists:
     type: "string"
     enum: 

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -415,6 +415,7 @@ definitions:
     enum:
       - NameAndAddress
       - IdAndSelfie
+      - PersonalDataAndDocuments
   FiatType:
     type: "string"
     enum:

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -442,11 +442,11 @@ definitions:
   FiatAccountTypeEnum:
     type: "string"
     enum:
-      - CreditCard
-      - DebitCard
-      - CheckingAccount
+      - BankAccount
   FiatAccountSchemaEnum:
     type: "string"
+    enum:
+      - AccountNumber
   QuoteRequest:
     type: "object"
     properties:


### PR DESCRIPTION
Includes updates from the following spec changes:
- add cREAL currency [fiatconnect/specification#23](https://github.com/fiatconnect/specification/pull/23)
- add AccountNumber fiat account type [fiatconnect/specification#16](https://github.com/fiatconnect/specification/pull/16)
- add InvalidParameters error [fiatconnect/specification#14](https://github.com/fiatconnect/specification/pull/14)
- add PersonalDataAndDocuments kyc type [fiatconnect/specification#6](https://github.com/fiatconnect/specification/pull/6)