### PR TITLE
Added BankAccount schema

### DIFF
--- a/fiatconnect-api.md
+++ b/fiatconnect-api.md
@@ -2095,7 +2095,10 @@ An enum listing the frequency, or how often, a particular fee needs to be paid.
 
 ```
 [
-	`AccountNumber`
+	`AccountNumber`,
+	`MobileMoney`,
+	`DuniaWallet`,
+	`IBANNumber`
 ]
 ```
 

--- a/fiatconnect-api.md
+++ b/fiatconnect-api.md
@@ -225,7 +225,7 @@
       - [8.3.2.2. `MobileMoney`](#8322-mobilemoney)
         * [8.3.2.2.1. `SupportedOperatorEnum`](#83221-supportedoperatorenum)
       - [8.3.2.3. `DuniaWallet`](#8323-duniawallet)
-      - [8.3.2.4. `BankAccount`](#8324-bankaccount)
+      - [8.3.2.4. `IBANNumber`](#8324-ibannumber)
 - [9. References](#9-references)
   * [9.1. Normative References](#91-normative-references)
     + [9.1.1. [RFC2119]](#911--rfc2119-)

--- a/fiatconnect-api.md
+++ b/fiatconnect-api.md
@@ -2216,7 +2216,7 @@ platform can be used to consume Fiat Connect services by providing their `mobile
 
 ####  8.3.2.4. `BankAccount`
 
-`BankAccount` is a representation of a bank account that is agnostic to the user's home country. The most important field is the `iban`, which stands for International Bank Account Number. More info on [Wikipedia](https://en.wikipedia.org/wiki/International_Bank_Account_Number) and [World First](https://www.worldfirst.com/uk/help-support/what-is-an-iban-number/).
+`IBANNumber` is a representation of a bank account that is agnostic to the user's home country. The most important field is the `iban`, which stands for International Bank Account Number. More info on [Wikipedia](https://en.wikipedia.org/wiki/International_Bank_Account_Number) and [World First](https://www.worldfirst.com/uk/help-support/what-is-an-iban-number/).
 
 ```
 {

--- a/fiatconnect-api.md
+++ b/fiatconnect-api.md
@@ -2229,7 +2229,7 @@ platform can be used to consume Fiat Connect services by providing their `mobile
 }
 ```
 
-The `country` field should be a [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) country code. `bankName` was added for verification purpose only (In a case where there maybe a mistake as each bank located in a specific country can only have a unique international identifier).
+The `country` field MUST be a [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) country code. `bankName` was added for verification purpose only (In a case where there maybe a mistake as each bank located in a specific country can only have a unique international identifier).
 
 # 9. References
 

--- a/fiatconnect-api.md
+++ b/fiatconnect-api.md
@@ -2229,7 +2229,7 @@ platform can be used to consume Fiat Connect services by providing their `mobile
 }
 ```
 
-The `country` field should be a [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) country code. `bankName` was added for verification purpose only(In a case where there maybe a mistake as each bank located in a specific country can only have a unique international identifier).
+The `country` field should be a [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) country code. `bankName` was added for verification purpose only (In a case where there maybe a mistake as each bank located in a specific country can only have a unique international identifier).
 
 # 9. References
 

--- a/fiatconnect-api.md
+++ b/fiatconnect-api.md
@@ -2223,13 +2223,12 @@ platform can be used to consume Fiat Connect services by providing their `mobile
 	accountName: `string`,
 	institutionName: `string`,
 	iban: `string`,
-  bankName?: `string`,
 	country: `string`,
 	fiatAccountType: `FiatAccountTypeEnum.BankAccount`
 }
 ```
 
-The `country` field MUST be a [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) country code. `bankName` was added for verification purpose only (In a case where there maybe a mistake as each bank located in a specific country can only have a unique international identifier).
+The `country` field MUST be a [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) country code.
 
 # 9. References
 

--- a/fiatconnect-api.md
+++ b/fiatconnect-api.md
@@ -2214,7 +2214,7 @@ platform can be used to consume Fiat Connect services by providing their `mobile
 }
 ```
 
-####  8.3.2.4. `BankAccount`
+####  8.3.2.4. `IBANNumber`
 
 `IBANNumber` is a representation of a bank account that is agnostic to the user's home country. The most important field is the `iban`, which stands for International Bank Account Number. More info on [Wikipedia](https://en.wikipedia.org/wiki/International_Bank_Account_Number) and [World First](https://www.worldfirst.com/uk/help-support/what-is-an-iban-number/).
 

--- a/fiatconnect-api.md
+++ b/fiatconnect-api.md
@@ -225,6 +225,7 @@
       - [8.3.2.2. `MobileMoney`](#8322-mobilemoney)
         * [8.3.2.2.1. `SupportedOperatorEnum`](#83221-supportedoperatorenum)
       - [8.3.2.3. `DuniaWallet`](#8323-duniawallet)
+      - [8.3.2.4. `BankAccount`](#8324-bankaccount)
 - [9. References](#9-references)
   * [9.1. Normative References](#91-normative-references)
     + [9.1.1. [RFC2119]](#911--rfc2119-)
@@ -2212,6 +2213,23 @@ platform can be used to consume Fiat Connect services by providing their `mobile
   fiatAccountType: `FiatAccountTypeEnum.DuniaWallet`
 }
 ```
+
+####  8.3.2.4. `BankAccount`
+
+`BankAccount` is a Fiat Account schema that tends to come up with a bank account representation we can use regardless of the country. Meanwhile, the most important field there is the `iban` that stands for International Bank Account Number. It respects a specific organization that you can find here [**IBAN on WIKIPEDIA**](https://fr.wikipedia.org/wiki/International_Bank_Account_Number) and [**IBAN**](https://www.pricebank.fr/questions-reponses/questions-frequentes/qu-est-ce-que-le-code-iban.html).
+
+```
+{
+	accountName: `string`,
+	institutionName: `string`,
+	iban: `string`,
+  bankName?: `string`,
+	country: `string`,
+	fiatAccountType: `FiatAccountTypeEnum.BankAccount`
+}
+```
+
+The `country` field should be a [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) country code. `bankName` was added for verification purpose only(In a case where there maybe a mistake as each bank located in a specific country can only have a unique international identifier).
 
 # 9. References
 

--- a/fiatconnect-api.md
+++ b/fiatconnect-api.md
@@ -2216,7 +2216,7 @@ platform can be used to consume Fiat Connect services by providing their `mobile
 
 ####  8.3.2.4. `BankAccount`
 
-`BankAccount` is a Fiat Account schema that tends to come up with a bank account representation we can use regardless of the country. Meanwhile, the most important field there is the `iban` that stands for International Bank Account Number. It respects a specific organization that you can find here [**IBAN on WIKIPEDIA**](https://fr.wikipedia.org/wiki/International_Bank_Account_Number) and [**IBAN**](https://www.pricebank.fr/questions-reponses/questions-frequentes/qu-est-ce-que-le-code-iban.html).
+`BankAccount` is a representation of a bank account that is agnostic to the user's home country. The most important field is the `iban`, which stands for International Bank Account Number. More info on [Wikipedia](https://fr.wikipedia.org/wiki/International_Bank_Account_Number) and [pricebank.fr FAQs page](https://www.pricebank.fr/questions-reponses/questions-frequentes/qu-est-ce-que-le-code-iban.html).
 
 ```
 {

--- a/fiatconnect-api.md
+++ b/fiatconnect-api.md
@@ -2216,13 +2216,13 @@ platform can be used to consume Fiat Connect services by providing their `mobile
 
 ####  8.3.2.4. `BankAccount`
 
-`BankAccount` is a representation of a bank account that is agnostic to the user's home country. The most important field is the `iban`, which stands for International Bank Account Number. More info on [Wikipedia](https://fr.wikipedia.org/wiki/International_Bank_Account_Number) and [pricebank.fr FAQs page](https://www.pricebank.fr/questions-reponses/questions-frequentes/qu-est-ce-que-le-code-iban.html).
+`BankAccount` is a representation of a bank account that is agnostic to the user's home country. The most important field is the `iban`, which stands for International Bank Account Number. More info on [Wikipedia](https://en.wikipedia.org/wiki/International_Bank_Account_Number) and [World First](https://www.worldfirst.com/uk/help-support/what-is-an-iban-number/).
 
 ```
 {
 	accountName: `string`,
 	institutionName: `string`,
-	iban: `string`,
+	ibanNumber: `string`,
   bankName?: `string`,
 	country: `string`,
 	fiatAccountType: `FiatAccountTypeEnum.BankAccount`

--- a/fiatconnect-api.md
+++ b/fiatconnect-api.md
@@ -2219,7 +2219,8 @@ platform can be used to consume Fiat Connect services by providing their `mobile
 
 ####  8.3.2.4. `IBANNumber`
 
-`IBANNumber` is a representation of a bank account that is agnostic to the user's home country. The most important field is the `iban`, which stands for International Bank Account Number. More info on [Wikipedia](https://en.wikipedia.org/wiki/International_Bank_Account_Number) and [World First](https://www.worldfirst.com/uk/help-support/what-is-an-iban-number/).
+`IBANNumber` is a representation of a bank account that is agnostic to the user's home country. The primary identifying field is `iban`, which represents an
+[International Bank Account Number](https://en.wikipedia.org/wiki/International_Bank_Account_Number). See [here](https://www.worldfirst.com/uk/help-support/what-is-an-iban-number/) for more context.
 
 ```
 {
@@ -2231,7 +2232,8 @@ platform can be used to consume Fiat Connect services by providing their `mobile
 }
 ```
 
-The `country` field MUST be a [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) country code.
+The `country` field MUST be a [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) country code. The syntax of the `iban` field MUST correspond to that of a valid International
+Bank Account Number.
 
 # 9. References
 

--- a/fiatconnect-api.md
+++ b/fiatconnect-api.md
@@ -2222,7 +2222,7 @@ platform can be used to consume Fiat Connect services by providing their `mobile
 {
 	accountName: `string`,
 	institutionName: `string`,
-	ibanNumber: `string`,
+	iban: `string`,
   bankName?: `string`,
 	country: `string`,
 	fiatAccountType: `FiatAccountTypeEnum.BankAccount`


### PR DESCRIPTION
Hey @jophish and @jh2oman, as stated in one of our previous meeting, I created a branch to implement the `BankAccount` schema based on the IBAN. 
As, I know it is one of the most use bank account number ID, my thoughts were to use it as property for CI/CO providers that provided bank services.