### PR TITLE
chore(ci): fix validate swagger workflow

### DIFF
--- a/.github/workflows/validate-swagger.yml
+++ b/.github/workflows/validate-swagger.yml
@@ -17,6 +17,6 @@ jobs:
     name: Validate Swagger
     steps:
       - uses: actions/checkout@v2
-      - name: Validate OpenAPI definition
       - run: yarn
-      - run: yarn validate
+      - name: Validate OpenAPI definition
+        run: yarn validate

--- a/.github/workflows/validate-swagger.yml
+++ b/.github/workflows/validate-swagger.yml
@@ -18,4 +18,5 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Validate OpenAPI definition
-        run: yarn validate
+      - run: yarn
+      - run: yarn validate


### PR DESCRIPTION
`error Command "swagger-cli" not found.` in another PR: https://github.com/fiatconnect/specification/runs/6498938289?check_suite_focus=true