### PR TITLE
feat(quotes): add tranferType field to successful quote responses

### DIFF
--- a/fiatconnect-api.md
+++ b/fiatconnect-api.md
@@ -787,7 +787,7 @@ On success, the server MUST return an HTTP `200`, with the following response bo
 		cryptoAmount: `float`,
 		quoteId: `string`,
 		guaranteedUntil: `string`,
-    transferType: `TransferTypeEnum.TransferIn`
+		transferType: `TransferTypeEnum.TransferIn`
 	},
 	kyc: {
 		kycRequired: `boolean`,
@@ -959,7 +959,7 @@ On success, the server MUST return an HTTP `200`, with the following response bo
 		cryptoAmount: `float`,
 		quoteId: `string`,
 		guaranteedUntil: `string`,
-    transferType: `TransferTypeEnum.TransferOut`
+		transferType: `TransferTypeEnum.TransferOut`
 	},
 	kyc: {
 		kycRequired: `boolean`,

--- a/fiatconnect-api.md
+++ b/fiatconnect-api.md
@@ -786,7 +786,8 @@ On success, the server MUST return an HTTP `200`, with the following response bo
 		fiatAmount: `float`,
 		cryptoAmount: `float`,
 		quoteId: `string`,
-		guaranteedUntil: `string`
+		guaranteedUntil: `string`,
+    transferType: `TransferTypeEnum.TransferIn`
 	},
 	kyc: {
 		kycRequired: `boolean`,
@@ -957,7 +958,8 @@ On success, the server MUST return an HTTP `200`, with the following response bo
 		fiatAmount: `float`,
 		cryptoAmount: `float`,
 		quoteId: `string`,
-		guaranteedUntil: `string`
+		guaranteedUntil: `string`,
+    transferType: `TransferTypeEnum.TransferOut`
 	},
 	kyc: {
 		kycRequired: `boolean`,

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -119,6 +119,8 @@ definitions:
             type: "string"
           guaranteedUntil:
             type: "string"
+          transferType:
+            $ref: '#/definitions/TransferType'
       kyc:
         type: "object"
         properties:

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -120,7 +120,7 @@ definitions:
           guaranteedUntil:
             type: "string"
           transferType:
-            $ref: '#/definitions/TransferType'
+            $ref: '#/definitions/TransferTypeEnum'
       kyc:
         type: "object"
         properties:
@@ -233,16 +233,18 @@ definitions:
       - TransferReceivedCryptoFunds
       - TransferComplete
       - TransferFailed
+  TransferTypeEnum:
+    type: "string"
+    enum: &TransferTypeEnum
+      - TransferIn
+      - TransferOut
   TransferStatusResponse:
     type: "object"
     properties:
       status:
         $ref: '#/definitions/TransferStatusEnum'
       transferType:
-        type: "string"
-        enum:
-          - TransferIn
-          - TransferOut
+        $ref: '#/definitions/TransferTypeEnum'
       fiatType:
         $ref: '#/definitions/FiatType'
       cryptoType:


### PR DESCRIPTION
It should be evident just by looking at a response object for a quote whether that quote is for a transfer out or a transfer in