### PR TITLE
docs(fee): update swagger description to match fees

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -132,6 +132,12 @@ definitions:
             type: "string"
           cryptoAmount:
             type: "string"
+          fee?:
+            type: "string"
+          feeType?:
+            $ref: '#/definitions/FeeType'
+          feeFrequency?:
+            $ref: '#/definitions/FeeFrequency'
           quoteId:
             type: "string"
           guaranteedUntil:
@@ -179,12 +185,6 @@ definitions:
                 type: "array"
                 items:
                   $ref: '#/definitions/FiatAccountSchemaEnum'
-              fee?:
-                type: "string"
-              feeType?:
-                $ref: '#/definitions/FeeType'
-              feeFrequency?:
-                $ref: '#/definitions/FeeFrequency'
               settlementTimeLowerBound?:
                 type: "string"
               settlementTimeUpperBound?:


### PR DESCRIPTION
This addes to change in documentation in #78 by moving the `QuoteResponse` fee entries to under `quote` from nested under `fiatAccount`.