### PR TITLE
refactor(mobile-money): change mobile money operator field to string

### DIFF
--- a/fiatconnect-api.md
+++ b/fiatconnect-api.md
@@ -236,7 +236,6 @@
     - [9.3.2. Fiat Account Schemas](#932-fiat-account-schemas)
       - [9.3.2.1. `AccountNumber`](#9321-accountnumber)
       - [9.3.2.2. `MobileMoney`](#9322-mobilemoney)
-        - [9.3.2.2.1. `SupportedOperatorEnum`](#93221-supportedoperatorenum)
       - [9.3.2.3. `DuniaWallet`](#9323-duniawallet)
       - [9.3.2.4. `IBANNumber`](#9324-ibannumber)
       - [9.3.2.5. `IFSCAccount`](#9325-ifscaccount)
@@ -2266,8 +2265,10 @@ is below:
 
 #### 9.3.2.2. `MobileMoney`
 
-Most of the mobile money's providers require only the phone number to process a transaction.  So, the best approach to make this schema general, is to add the *operator*.
-`Operator` represents the name of the mobile operator and `mobile` the phone number of the end-users. The property `mobile` should follow the [International format E.164 from ITU-T](https://en.wikipedia.org/wiki/E.164) (i.e., +14155552671 for US). Finally, the `country` field should be a [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) country code.
+`MobileMoney` is a fiat account schema pertaining to virtual wallets provided by telecommunications companies in Africa.
+The `operator` field represents the name of the mobile operator, and `mobile` is the phone number of the end user. 
+The property `mobile` MUST follow the [International format E.164 from ITU-T](https://en.wikipedia.org/wiki/E.164) 
+with a plus sign prefix (i.e., +14155552671 for US). Finally, the `country` field MUST be a [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) country code.
 
 ```
 {
@@ -2275,31 +2276,10 @@ Most of the mobile money's providers require only the phone number to process a 
   institutionName: `string`,
   mobile: `string`,
   country: `string`,
-  operator: `SupportedOperatorEnum`,
+  operator: `string`,
   fiatAccountType: `FiatAccountTypeEnum.MobileMoney`
 }
 ```
-
-##### 9.3.2.2.1. `SupportedOperatorEnum`
-
-Depending on the `allowedValues` field for `operator` in each country, the client SHOULD impose restrictions on the type of data the user can provide for the `operator` field. This data should be part of the `SupportedOperatorEnum` provided. Depending on mobile money providers supported on a specific country, CI/CO providers will provide the list of `allowedValues`.
-Below you have a list of mobile money providers:
-
-(PS: Only missing mobile money providers should be added regardless of the country).
-
-```
-[
-  `ORANGE`,
-  `MOOV`,
-  `MTN`,
-  `WAVE`
-]
-```
-
-- `ORANGE` - [Orange Money](https://en.wikipedia.org/wiki/Orange_Money)
-- `MOOV` - [Moov Money](https://www.moov-africa.ci/moov-money/)
-- `MTN` - [Momo or Mtn Money](https://www.mtn.ci/vos/depot-et-retrait-momo/)
-- `WAVE` - [Wave](https://www.wave.com/fr/)
 
 #### 9.3.2.3. `DuniaWallet`
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "specification",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "FiatConnect API Specification",
   "repository": "https://github.com/fiatconnect/specification.git",
   "scripts": {

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -1,7 +1,7 @@
 swagger: "2.0"
 info:
   description: "FiatConnect provides a standardized server-side API specification for CICO providers to provide cash-in/cash-out functionality to clients."
-  version: "1.0.0"
+  version: "1.0.1"
   title: "FiatConnect Specification"
 tags:
 - name: "clock"


### PR DESCRIPTION
There are only 4 supported operators in the spec, and about 144 in sub-saharan Africa alone. Given that this list may also change over time, I don't think it's wise to try to maintain an enum so large in the FiatConnect spec and all the downstream repos that depend on it (particularly https://github.com/fiatconnect/fiatconnect-types).

I suggest that CICO providers use allowedValues to enumerate the mobile money operators supported by their API. Otherwise, clients are welcome to implement their own drop-downs or auto-complete algorithms for this field to try to proactively sanitize the user inputs and prevent users from getting transfers rejected on account of bad `operator` inputs. (Again, CICO providers are ultimately responsible for advertising the list of mobile money providers that they will support, which they can do using the allowedValues field on a quote response.)