### PR TITLE
feat:Adding ability to send back picture of Id document

### DIFF
--- a/fiatconnect-api.md
+++ b/fiatconnect-api.md
@@ -2269,14 +2269,13 @@ The `phoneNumber` field is REQUIRED and MUST follow the formating of the [E.164 
 The `email` field is OPTIONAL but if provided MUST be a [valid email](https://en.wikipedia.org/wiki/Email_address#Syntax).
 
 The accepted documents can be found [here](https://en.wikipedia.org/wiki/Identity_document). The document should fit one of the `identificationDocumentType` field options:
-- `IDC`: Identity card
+- `IDC`: State issued identity card
 - `PAS`: Passport
 - `DL`: Driving Liscense
-- `DNI`: Documento Nacional de Identidad
 
 The `selfieDocument`, `identificationDocumentFront` and `identificationDocumentFront` fields should be base64 encoded binary blobs representing images.
 
-The `identificationDocumentBack` field is OPTIONAL as some Id documents like a passport do not require a Back image for a full KYC check, but some others like an Identity Card do.
+The `identificationDocumentBack` field is REQUIRED if the `identificationDocumentType` is `IDC` or `DL`
 
 
 ### 9.3.2. Fiat Account Schemas

--- a/fiatconnect-api.md
+++ b/fiatconnect-api.md
@@ -2148,7 +2148,7 @@ An enum listing the KYC schema types recognized by the FiatConnect specification
 ```
 [
 	`PersonalDataAndDocuments`,
-	`PersonalDataAndDocumentsWithBack`
+	`PersonalDataAndDocumentsDetailed`
 ]
 ```
 

--- a/fiatconnect-api.md
+++ b/fiatconnect-api.md
@@ -2258,11 +2258,17 @@ A more detailed Schema allowing the user to provide more information to give the
 	selfieDocument: `string`,
     identificationDocumentType: `string`,
 	identificationDocumentFront: `string`,
-    identificationDocumentBack: `string`
+    identificationDocumentBack?: `string` 
 }
 ```
 
 The `identificationDocumentBack` field is OPTIONAL as some Id documents like a passport do not require a Back image for a full KYC check, but some others like an Identity Card do.
+
+The `identificationDocumentType` field should contain either of the following options:
+- `IDC`: Identity card
+- `PAS`: Passport
+- `DL`: Driving Liscense
+- `DNI`: Documento Nacional de Identidad
 
 
 ### 9.3.2. Fiat Account Schemas

--- a/fiatconnect-api.md
+++ b/fiatconnect-api.md
@@ -2255,7 +2255,6 @@ A more detailed Schema allowing the user to provide more information to give the
 		city: `string`,
 		postalCode?: `string`
 	},
-    countryCode: `enum`,
 	phoneNumber: `string`,
     email?: `string`,
 	selfieDocument: `string`,
@@ -2265,17 +2264,7 @@ A more detailed Schema allowing the user to provide more information to give the
 }
 ```
 
-The `countryCode` field is REQUIRED and MUST follow the formating of the [E.164 international standard](https://en.wikipedia.org/wiki/E.164), here is the format simplified:
-- +XZZ
-
-`X` MUST be a number and `Z` is an OPTIONAL potential numbers.
-
-Examples:
-- +1 for the United States
-- +44 for the United Kingdom
-- +250 for Rwanda
-
-The `phoneNumber` field is REQUIRED and MUST follow the formating of the [E.164 international standard](https://en.wikipedia.org/wiki/E.164). It MUST contain all parts of the phone number EXPECT the `countryCode`
+The `phoneNumber` field is REQUIRED and MUST follow the formating of the [E.164 international standard](https://en.wikipedia.org/wiki/E.164). It MUST contain all parts of the phone number INCLUDING the Country Code.
 
 The `email` field is OPTIONAL but if provided MUST be a [valid email](https://en.wikipedia.org/wiki/Email_address#Syntax).
 

--- a/fiatconnect-api.md
+++ b/fiatconnect-api.md
@@ -234,7 +234,7 @@
     - [9.3.1. KYC Schemas](#931-kyc-schemas)
       - [9.3.1.1. `PersonalDataAndDocuments`](#9311-personaldataanddocuments)
       - [9.3.1.2. `PersonalDataAndDocumentsDetailed`](#9312-personaldataanddocumentsdetailed)
-        - [9.3.1.2.1. `]
+        - [9.3.1.2.1. `IdentificationDocumentType`] (#93121-identificationdocumenttype)
     - [9.3.2. Fiat Account Schemas](#932-fiat-account-schemas)
       - [9.3.2.1. `AccountNumber`](#9321-accountnumber)
       - [9.3.2.2. `MobileMoney`](#9322-mobilemoney)
@@ -2136,10 +2136,10 @@ An enum listing the types of crypto tokens supported by FiatConnect.
 
 ```
 [
-  `cUSD`,
-  `cEUR`,
-  `cREAL`,
-  `CELO`
+	`cUSD`,
+	`cEUR`,
+	`cREAL`,
+	`CELO`
 ]
 ```
 
@@ -2230,7 +2230,7 @@ A KYC schema containing personal data about a user, as well as documents such as
 	},
 	phoneNumber: `string`,
 	selfieDocument: `string`,
-  identificationDocument: `string`
+	identificationDocument: `string`
 }
 ```
 
@@ -2258,31 +2258,31 @@ A more detailed Schema allowing the user to provide more information to work wit
 		postalCode?: `string`
 	},
 	phoneNumber: `string`,
-  email?: `string`,
+	email?: `string`,
 	selfieDocument: `string`,
-  identificationDocumentType: `IdentificationDocumentTypeEnum`,
+	identificationDocumentType: `IdentificationDocumentTypeEnum`,
 	identificationDocumentFront: `string`,
-  identificationDocumentBack?: `string` 
+	identificationDocumentBack?: `string` 
 }
 ```
 
-The `phoneNumber` field is REQUIRED and MUST follow the formating of the [E.164 international standard](https://en.wikipedia.org/wiki/E.164). It MUST contain all parts of the phone number INCLUDING the Country Code.
+The `phoneNumber` field is REQUIRED and MUST follow the formating of the [E.164 international standard](https://en.wikipedia.org/wiki/E.164). It MUST contain all parts of the phone number including the Country Code.
 
 The `email` field MUST be a [valid email](https://en.wikipedia.org/wiki/Email_address#Syntax).
 
-The `identificationDocumentType` field must be selected from `IdentificationDocumentTypeEnum`, and is used to represent the kind of document being submitted.
+The `identificationDocumentType` field MUST be selected from `IdentificationDocumentTypeEnum`, and is used to represent the kind of document being submitted.
 
-The `selfieDocument`, `identificationDocumentFront` and `identificationDocumentFront` fields MUST be base64 encoded binary blobs representing images.
+The `selfieDocument`, `identificationDocumentFront` and `identificationDocumentBack` fields MUST be base64 encoded binary blobs representing images.
 
-The `identificationDocumentBack` field is REQUIRED if the `identificationDocumentType` is `IDC` or `DL`. Otherwise, it is optional.
+The `identificationDocumentBack` field is REQUIRED if the `identificationDocumentType` is `IDC` or `DL`. Otherwise, it is OPTIONAL.
 
 ##### 9.3.1.2.1. `IdentificationDocumentType`
 `IdentificationDocumentType` is used to represent the type of document being submitted with a `PersonalDataAndDocumentsDetailed` KYC schema.
 ```
 [
-  `IDC`,
-  `PAS`,
-  `DL`
+	`IDC`,
+	`PAS`,
+	`DL`
 ]
 ```
 The enum values represent the following forms of identification:

--- a/fiatconnect-api.md
+++ b/fiatconnect-api.md
@@ -2255,55 +2255,38 @@ A more detailed Schema allowing the user to provide more information to give the
 		city: `string`,
 		postalCode?: `string`
 	},
+    countryCode: `enum`,
 	phoneNumber: `string`,
+    email?: `string`,
 	selfieDocument: `string`,
-    identificationDocumentType: `string`,
+    identificationDocumentType: `enum`,
 	identificationDocumentFront: `string`,
     identificationDocumentBack?: `string` 
 }
 ```
 
-The `identificationDocumentBack` field is OPTIONAL as some Id documents like a passport do not require a Back image for a full KYC check, but some others like an Identity Card do.
+The `countryCode` field is REQUIRED and MUST follow the formating of the [E.164 international standard](https://en.wikipedia.org/wiki/E.164), here is the format simplified:
+- +XZZ
 
-The `identificationDocumentType` field should contain either of the following options:
+`X` MUST be a number and `Z` is an OPTIONAL potential numbers.
+
+Examples:
+- +1 for the United States
+- +44 for the United Kingdom
+- +250 for Rwanda
+
+The `phoneNumber` field is REQUIRED and MUST follow the formating of the [E.164 international standard](https://en.wikipedia.org/wiki/E.164). It MUST contain all parts of the phone number EXPECT the `countryCode`
+
+The `email` field is OPTIONAL but if provided MUST be a [valid email](https://en.wikipedia.org/wiki/Email_address#Syntax).
+
+The accepted documents can be found [here](https://en.wikipedia.org/wiki/Identity_document). The document should fit one of the `identificationDocumentType` field options:
 - `IDC`: Identity card
 - `PAS`: Passport
 - `DL`: Driving Liscense
 - `DNI`: Documento Nacional de Identidad
 
+The `identificationDocumentBack` field is OPTIONAL as some Id documents like a passport do not require a Back image for a full KYC check, but some others like an Identity Card do.
 
-#### 9.3.1.2. `PersonalDataAndDocumentsWithBack`
-
-A KYC schema containing personal data about a user, as well as documents such as an ID, photo and selfie.
-The accepted documents are [RG](https://en.wikipedia.org/wiki/Brazilian_identity_card), [CNH](https://en.wikipedia.org/wiki/Driving_licence_in_Brazil) and [RNM](https://en.wikipedia.org/wiki/Registro_Nacional_de_Estrangeiros)
-
-```
-{
-	fullName: `string`,
-	dateOfBirth: {
-		day: `string`,
-		month: `string`,
-		year: `string`
-	},
-	address: {
-		address1: `string`,
-		address2?: `string`,
-		isoCountryCode: `string`,
-		isoRegionCode: `string`,
-		city: `string`,
-		postalCode?: `string`
-	},
-	phoneNumber: `string`,
-	email: `string`,
-	selfieDocument: `string`,
-	identificationDocumentFront: `string`,
-	identificationDocumentBack: `string`,
-}
-```
-
-`email` MUST be a [valid email](https://en.wikipedia.org/wiki/Email_address#Syntax).
-`phoneNumber` MUST be an 11-digit [Brazilian mobile phone number](https://en.wikipedia.org/wiki/Telephone_numbers_in_Brazil) including area code. The string MUST match the regex `/[0-9]{11}/`.
-The `selfieDocument`, `identificationDocument` and `identificationDocumentBack` fields should be base64 encoded binary blobs representing images.
 
 ### 9.3.2. Fiat Account Schemas
 

--- a/fiatconnect-api.md
+++ b/fiatconnect-api.md
@@ -2232,7 +2232,7 @@ A KYC schema containing personal data about a user, as well as documents such as
 }
 ```
 
-The `selfieDocument`, `identificationDocumentFront` and `identificationDocumentBack` fields should be base64 encoded binary blobs representing images.
+The `selfieDocument` and `identificationDocument` fields should be base64 encoded binary blobs representing images.
 
 #### 9.3.1.2. `PersonalDataAndDocumentsDetailed`
 A more detailed Schema allowing the user to provide more information to give them a greater chance to be admitted.
@@ -2284,6 +2284,8 @@ The accepted documents can be found [here](https://en.wikipedia.org/wiki/Identit
 - `PAS`: Passport
 - `DL`: Driving Liscense
 - `DNI`: Documento Nacional de Identidad
+
+The `selfieDocument`, `identificationDocumentFront` and `identificationDocumentFront` fields should be base64 encoded binary blobs representing images.
 
 The `identificationDocumentBack` field is OPTIONAL as some Id documents like a passport do not require a Back image for a full KYC check, but some others like an Identity Card do.
 

--- a/fiatconnect-api.md
+++ b/fiatconnect-api.md
@@ -2227,14 +2227,43 @@ A KYC schema containing personal data about a user, as well as documents such as
 	},
 	phoneNumber: `string`,
 	selfieDocument: `string`,
-	identificationDocumentFront: `string`,
-    identificationDocumentBack: `string`
+    identificationDocument: `string`
 }
 ```
 
 The `selfieDocument`, `identificationDocumentFront` and `identificationDocumentBack` fields should be base64 encoded binary blobs representing images.
 
+#### 9.3.1.2. `PersonalDataAndDocumentsDetailed`
+A more detailed Schema allowing the user to provide more information to give them a greater chance to be admitted.
+
+```
+{
+	firstName: `string`,
+	middleName?: `string`,
+	lastName: `string`,
+	dateOfBirth: {
+		day: `string`,
+		month: `string`,
+		year: `string`
+	},
+	address: {
+		address1: `string`,
+		address2?: `string`,
+		isoCountryCode: `string`,
+		isoRegionCode: `string`,
+		city: `string`,
+		postalCode?: `string`
+	},
+	phoneNumber: `string`,
+	selfieDocument: `string`,
+    identificationDocumentType: `string`,
+	identificationDocumentFront: `string`,
+    identificationDocumentBack: `string`
+}
+```
+
 The `identificationDocumentBack` field is OPTIONAL as some Id documents like a passport do not require a Back image for a full KYC check, but some others like an Identity Card do.
+
 
 ### 9.3.2. Fiat Account Schemas
 

--- a/fiatconnect-api.md
+++ b/fiatconnect-api.md
@@ -2258,11 +2258,7 @@ A more detailed Schema allowing the user to provide more information to work wit
 		postalCode?: `string`
 	},
 	phoneNumber: `string`,
-<<<<<<< HEAD
-    email: `string`,
-=======
   email?: `string`,
->>>>>>> 42f0d44 (added a desciption of the)
 	selfieDocument: `string`,
   identificationDocumentType: `IdentificationDocumentTypeEnum`,
 	identificationDocumentFront: `string`,
@@ -2274,14 +2270,7 @@ The `phoneNumber` field is REQUIRED and MUST follow the formating of the [E.164 
 
 The `email` field MUST be a [valid email](https://en.wikipedia.org/wiki/Email_address#Syntax).
 
-<<<<<<< HEAD
-The accepted documents can be found [here](https://en.wikipedia.org/wiki/Identity_document). The document should fit one of the `identificationDocumentType` field options:
-- `IDC`: State issued identity card
-- `PAS`: Passport
-- `DL`: Driving Liscense
-=======
 The `identificationDocumentType` field must be selected from `IdentificationDocumentTypeEnum`, and is used to represent the kind of document being submitted.
->>>>>>> 42f0d44 (added a desciption of the)
 
 The `selfieDocument`, `identificationDocumentFront` and `identificationDocumentFront` fields MUST be base64 encoded binary blobs representing images.
 

--- a/fiatconnect-api.md
+++ b/fiatconnect-api.md
@@ -233,6 +233,8 @@
   - [9.3. Initial Entity Support](#93-initial-entity-support)
     - [9.3.1. KYC Schemas](#931-kyc-schemas)
       - [9.3.1.1. `PersonalDataAndDocuments`](#9311-personaldataanddocuments)
+      - [9.3.1.2. `PersonalDataAndDocumentsDetailed`](#9312-personaldataanddocumentsdetailed)
+        - [9.3.1.2.1. `]
     - [9.3.2. Fiat Account Schemas](#932-fiat-account-schemas)
       - [9.3.2.1. `AccountNumber`](#9321-accountnumber)
       - [9.3.2.2. `MobileMoney`](#9322-mobilemoney)
@@ -2228,7 +2230,7 @@ A KYC schema containing personal data about a user, as well as documents such as
 	},
 	phoneNumber: `string`,
 	selfieDocument: `string`,
-    identificationDocument: `string`
+  identificationDocument: `string`
 }
 ```
 
@@ -2256,11 +2258,15 @@ A more detailed Schema allowing the user to provide more information to work wit
 		postalCode?: `string`
 	},
 	phoneNumber: `string`,
+<<<<<<< HEAD
     email: `string`,
+=======
+  email?: `string`,
+>>>>>>> 42f0d44 (added a desciption of the)
 	selfieDocument: `string`,
-    identificationDocumentType: `enum`,
+  identificationDocumentType: `IdentificationDocumentTypeEnum`,
 	identificationDocumentFront: `string`,
-    identificationDocumentBack?: `string` 
+  identificationDocumentBack?: `string` 
 }
 ```
 
@@ -2268,14 +2274,32 @@ The `phoneNumber` field is REQUIRED and MUST follow the formating of the [E.164 
 
 The `email` field MUST be a [valid email](https://en.wikipedia.org/wiki/Email_address#Syntax).
 
+<<<<<<< HEAD
 The accepted documents can be found [here](https://en.wikipedia.org/wiki/Identity_document). The document should fit one of the `identificationDocumentType` field options:
 - `IDC`: State issued identity card
 - `PAS`: Passport
 - `DL`: Driving Liscense
+=======
+The `identificationDocumentType` field must be selected from `IdentificationDocumentTypeEnum`, and is used to represent the kind of document being submitted.
+>>>>>>> 42f0d44 (added a desciption of the)
 
-The `selfieDocument`, `identificationDocumentFront` and `identificationDocumentFront` fields should be base64 encoded binary blobs representing images.
+The `selfieDocument`, `identificationDocumentFront` and `identificationDocumentFront` fields MUST be base64 encoded binary blobs representing images.
 
 The `identificationDocumentBack` field is REQUIRED if the `identificationDocumentType` is `IDC` or `DL`. Otherwise, it is optional.
+
+##### 9.3.1.2.1. `IdentificationDocumentType`
+`IdentificationDocumentType` is used to represent the type of document being submitted with a `PersonalDataAndDocumentsDetailed` KYC schema.
+```
+[
+  `IDC`,
+  `PAS`,
+  `DL`
+]
+```
+The enum values represent the following forms of identification:
+* `IDC`: State-issued identity card
+* `PAS`: Passport
+* `DL`: Driver's License
 
 
 ### 9.3.2. Fiat Account Schemas

--- a/fiatconnect-api.md
+++ b/fiatconnect-api.md
@@ -2235,7 +2235,7 @@ A KYC schema containing personal data about a user, as well as documents such as
 The `selfieDocument` and `identificationDocument` fields should be base64 encoded binary blobs representing images.
 
 #### 9.3.1.2. `PersonalDataAndDocumentsDetailed`
-A more detailed Schema allowing the user to provide more information to give them a greater chance to be admitted.
+A more detailed Schema allowing the user to provide more information to work with CICO providers that require it.
 
 ```
 {
@@ -2256,7 +2256,7 @@ A more detailed Schema allowing the user to provide more information to give the
 		postalCode?: `string`
 	},
 	phoneNumber: `string`,
-    email?: `string`,
+    email: `string`,
 	selfieDocument: `string`,
     identificationDocumentType: `enum`,
 	identificationDocumentFront: `string`,
@@ -2266,7 +2266,7 @@ A more detailed Schema allowing the user to provide more information to give the
 
 The `phoneNumber` field is REQUIRED and MUST follow the formating of the [E.164 international standard](https://en.wikipedia.org/wiki/E.164). It MUST contain all parts of the phone number INCLUDING the Country Code.
 
-The `email` field is OPTIONAL but if provided MUST be a [valid email](https://en.wikipedia.org/wiki/Email_address#Syntax).
+The `email` field MUST be a [valid email](https://en.wikipedia.org/wiki/Email_address#Syntax).
 
 The accepted documents can be found [here](https://en.wikipedia.org/wiki/Identity_document). The document should fit one of the `identificationDocumentType` field options:
 - `IDC`: State issued identity card
@@ -2275,7 +2275,7 @@ The accepted documents can be found [here](https://en.wikipedia.org/wiki/Identit
 
 The `selfieDocument`, `identificationDocumentFront` and `identificationDocumentFront` fields should be base64 encoded binary blobs representing images.
 
-The `identificationDocumentBack` field is REQUIRED if the `identificationDocumentType` is `IDC` or `DL`
+The `identificationDocumentBack` field is REQUIRED if the `identificationDocumentType` is `IDC` or `DL`. Otherwise, it is optional.
 
 
 ### 9.3.2. Fiat Account Schemas

--- a/fiatconnect-api.md
+++ b/fiatconnect-api.md
@@ -2227,11 +2227,14 @@ A KYC schema containing personal data about a user, as well as documents such as
 	},
 	phoneNumber: `string`,
 	selfieDocument: `string`,
-	identificationDocument: `string`
+	identificationDocumentFront: `string`,
+    identificationDocumentBack: `string`
 }
 ```
 
-The `selfieDocument` and `identificationDocument` fields should be base64 encoded binary blobs representing images.
+The `selfieDocument`, `identificationDocumentFront` and `identificationDocumentBack` fields should be base64 encoded binary blobs representing images.
+
+The `identificationDocumentBack` field is OPTIONAL as some Id documents like a passport do not require a Back image for a full KYC check, but some others like an Identity Card do.
 
 ### 9.3.2. Fiat Account Schemas
 

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -36,7 +36,7 @@ definitions:
       - NameAndAddress
       - IdAndSelfie
       - PersonalDataAndDocuments
-      - PersonalDataAndDocumentsWithBack
+      - PersonalDataAndDocumentsDetailed
   FiatType:
     type: "string"
     enum: &FiatType


### PR DESCRIPTION
In order to prevent fraud, most identity cards worldwide include anti-forgery specifications on the back. 

As a result, many Know Your Customer (KYC) providers require or allow the submission of the back of the identity card. To accommodate this requirement, we should support the submission of the back of identity cards as an optional field. 

It should be noted that not all identity documents, such as passports, require a back image to be submitted.



