### PR TITLE
fix: Make error and transfer enum values consistent with specification

### DIFF
--- a/fiatconnect-api.md
+++ b/fiatconnect-api.md
@@ -2045,7 +2045,8 @@ An enum listing the error types used by various endpoints.
 	`NonceInUse`,
 	`IssuedTooEarly`,
 	`ExpirationTooLong`,
-	`InvalidFiatAccount`
+	`InvalidFiatAccount`,
+	`InvalidQuote`
 ]
 ```
 
@@ -2084,6 +2085,7 @@ An enum listing the types of transfer statuses recognized by FiatConnect.
 	`TransferAmlFailed`,
 	`TransferReadyForUserToSendCryptoFunds`,
 	`TransferReceivedCryptoFunds`,
+	`TransferReceivedFiatFunds`,
 	`TransferComplete`,
 	`TransferFailed`
 ]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "specification",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "FiatConnect API Specification",
   "repository": "https://github.com/fiatconnect/specification.git",
   "scripts": {

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -291,6 +291,7 @@ definitions:
       - TransferAmlFailed
       - TransferReadyForUserToSendCryptoFunds
       - TransferReceivedCryptoFunds
+      - TransferReceivedFiatFunds
       - TransferComplete
       - TransferFailed
   TransferTypeEnum:


### PR DESCRIPTION
To match https://github.com/fiatconnect/fiatconnect-types/pull/117. These were missing from the enum in the spec, which is likely why they were also missing from the types repo.