### PR TITLE
feat(txhash): Add `txHash` to transfer in status responses

### DIFF
--- a/fiatconnect-api.md
+++ b/fiatconnect-api.md
@@ -1731,7 +1731,8 @@ On success, the server MUST return an HTTP `200` status code, along with a respo
 	fee?: `string`,
 	fiatAccountId: `string`,
 	transferId: `string`,
-	transferAddress: `string`
+	transferAddress: `string`,
+	txHash?: `string`
 }
 ```
 
@@ -1759,6 +1760,11 @@ If the user has a transfer on file with the corresponding `transferId`, the serv
 `amountProvided` refers to the amount of fiat or crypto that the user has provided for the transfer. `amountReceived` refers to the amount
 of crypto or fiat that the server will be crediting to the user. `fee`, if present refers to the fee, if any, associated with the transfer,
 denominated in fiat or crypto, depending on the transfer type. `fee` is given as a string-ified numerical amount (e.g. `"1.0"`).
+
+If the queried transfer represents a transfer in, and if the transfer has progressed to the point where the provider has sent crypto funds to the user,
+the `txHash` field MUST be present, and represent the hash of the transaction in which the provider sent the user crypto funds.
+The `txHash` MUST correspond to a valid transaction hash on the Celo blockchain, and its syntax must match the following regex: `/^0x([A-Fa-f0-9]{64})$/`;
+namely, it must be exactly the string `0x` followed by 64 hexadecimal characters.
 
 ###### 3.4.4.3.3.2. Failure
 
@@ -1872,7 +1878,7 @@ though these are rough guidelines. Once a server has received an HTTP `200` stat
 ### 5.1.2. `WebhookTransferInStatusEventSchema`
 
 `WebhookTransferInStatusEventSchema` is the schema that defines webhook payloads for transfer in events. Note that this schema is *identical* to the
-one returned from the `GET /transfer/:transferId/status` endpoint
+one returned from the `GET /transfer/:transferId/status` endpoint.
 
 ```
 {
@@ -1886,13 +1892,14 @@ one returned from the `GET /transfer/:transferId/status` endpoint
 	fiatAccountId: `string`,
 	transferId: `string`,
 	transferAddress: `string`
+	txHash?: `string`
 }
 ```
 
 ### 5.1.3. `WebhookTransferOutStatusEventSchema`
 
-`WebhookTransferOutStatusEventSchema` is the schema that defines webhook payloads for transfer out events. Note that this schema is *identical* to the
-one returned from the `GET /transfer/:transferId/status` endpoint
+`WebhookTransferOutStatusEventSchema` is the schema that defines webhook payloads for transfer out events. Note that this schema is nearly identical to the
+one returned from the `GET /transfer/:transferId/status` endpoint; it lacks the optional `txHash` field, since it is not relevenat for transfers out.
 
 ```
 {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "specification",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "FiatConnect API Specification",
   "repository": "https://github.com/fiatconnect/specification.git",
   "scripts": {

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -333,6 +333,8 @@ definitions:
         type: "string"
       transferAddress:
         type: "string"
+      txHash:
+        type: "string"
   TransferErrorEnum:
     type: "string"
     enum: &TransferErrorEnum


### PR DESCRIPTION
Currently, it is difficult, if not impossible, for a client to determine _which_ transaction on the blockchain represents the payment from provider to end-user for a transfer in. While the provider _does_ need to inform the client of the provider-owned address that funds will be sent from, this is not necessarily sufficient to determine the actual transfer that contains the sent funds (and even when it is "sufficient", it can be challenging and error-prone to track down the transaction). 

For example, if a user initiates two "transfer in" transactions _for similar amounts_ in parallel with a provider, and the provider sends funds from the same address for both transfers, it would be extremely difficult to determine which blockchain TX corresponds to which FC transfer.

This PR updates both the transfer status endpoint, and the `WebhookTransferInStatusEventSchema` webhook payload to contain an optional `txHash` field, so that clients can associate transfers in with their corresponding blockchain TX.