### PR TITLE
feat(transfers): Add support for user-initiated transfers in

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "specification",
-  "version": "1.0.3",
+  "version": "1.1.3",
   "description": "FiatConnect API Specification",
   "repository": "https://github.com/fiatconnect/specification.git",
   "scripts": {

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -101,6 +101,17 @@ definitions:
       - IBANNumber
       - IFSCAccount
       - PIXAccount
+  UserActionTypeEnum:
+    type: "string"
+    enum: &UserActionTypeEnum
+      - PIX
+      - IBAN
+      - PSE
+  UserActionDetails:
+    type: "object"
+    properties:
+      userActionType:
+        $ref: '#/definitions/UserActionTypeEnum'
   QuoteRequest:
     type: "object"
     properties:
@@ -186,7 +197,16 @@ definitions:
                 minimum: 1
                 type: "array"
                 items:
-                  $ref: '#/definitions/FiatAccountSchemaEnum'
+                  type: "object"
+                  required:
+                    - fiatAccountSchema
+                  properties:
+                    fiatAccountSchema:
+                      $ref: '#/definitions/FiatAccountSchemaEnum'
+                    userActionType:
+                      $ref: '#/definitions/UserActionTypeEnum'
+                    allowedValues:
+                      type: "object"
               settlementTimeLowerBound?:
                 type: "string"
               settlementTimeUpperBound?:
@@ -283,12 +303,15 @@ definitions:
         $ref: '#/definitions/TransferStatusEnum'
       transferAddress:
         type: "string"
+      userActionDetails:
+        $ref: '#/definitions/UserActionDetails'
   TransferStatusEnum:
     type: "string"
     enum: &TransferStatusEnum
       - TransferStarted
       - TransferFiatFundsDebited
       - TransferSendingCryptoFunds
+      - TransferWaitingForUserAction
       - TransferAmlFailed
       - TransferReadyForUserToSendCryptoFunds
       - TransferReceivedCryptoFunds
@@ -335,6 +358,8 @@ definitions:
         type: "string"
       txHash:
         type: "string"
+      userActionDetails:
+        $ref: '#/definitions/UserActionDetails'
   TransferErrorEnum:
     type: "string"
     enum: &TransferErrorEnum


### PR DESCRIPTION
Formalizes the discussion present in #93.

This PR adds formal support to the FiatConnect specification for user-initiated transfers in.

At a high level, this is accomplished by introducing two new (capital C) _Concepts_ to the FiatConnect specification: **User Action Type** and **User Action Details**. 

At the time of getting a quote from `POST /quote/in`, if a particular Fiat Account schema will require user action to send fiat funds to the provider, a _User Action Type_ should be specified alongside that schema in the quote response. When initiating the transfer by calling `POST /transfer/in`, if the fiat account being used for that transfer has a schema that was designated as requiring user action by the quote, the `POST /transfer/in` response will contain _User Action Details_, containing information required by the user in order to complete the action needed to progress the transfer. Each _User Action Type_ has a corresponding _User Action Details_ schema, each with different semantics.

I've included initial User Action Type/User Action Details support for `PIX`, `IBAN`, and `PSE`. Let me know if I'm missing something that you'll _immediately_ need support for; I don't want to bloat this PR with support for User Action Types/User Action Details that won't be immediately needed; those can always be added easily in a follow-on PR.