### PR TITLE
fix(swagger): Update user action detail enum in swagger spec

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "specification",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "FiatConnect API Specification",
   "repository": "https://github.com/fiatconnect/specification.git",
   "scripts": {

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -104,9 +104,9 @@ definitions:
   UserActionTypeEnum:
     type: "string"
     enum: &UserActionTypeEnum
-      - PIX
-      - IBAN
-      - PSE
+      - PIXUserAction
+      - IBANUserAction
+      - PSEUserAction
   UserActionDetails:
     type: "object"
     properties:


### PR DESCRIPTION
The user action details enum in the swagger spec differs from the actual specification, and thus the most recent changes to the fiatconnect-types repo. During testing, this was causing validations to fail where they shouldn't.