### PR TITLE
feat(user actions): Add URLUserAction schema

### DIFF
--- a/fiatconnect-api.md
+++ b/fiatconnect-api.md
@@ -243,9 +243,10 @@
       - [9.3.2.4. `IBANNumber`](#9324-ibannumber)
       - [9.3.2.5. `IFSCAccount`](#9325-ifscaccount)
     - [9.3.3. User Action Details Schemas](#933-user-action-details-schemas)
-      - [9.3.3.1. `PIXUserActionDetailsSchema`](#9331-pixuseractiondetailsschema)
-      - [9.3.3.2. `IBANUserActionDetailsSchema`](#9332-ibanuseractiondetailsschema)
-      - [9.3.3.3. `PSEUserActionDetailsSchema`](#9333-pseuseractiondetailsschema)
+      - [9.3.3.1. `PIXUserAction`](#9331-pixuseraction)
+      - [9.3.3.2. `IBANUserAction`](#9332-ibanuseraction)
+      - [9.3.3.3. `PSEUserAction`](#9333-pseuseraction)
+      - [9.3.3.3. `URLUserAction`](#9333-urluseraction)
 - [10. References](#10-references)
   - [10.1. Normative References](#101-normative-references)
     - [10.1.1. [RFC2119]](#1011-rfc2119)
@@ -2272,7 +2273,8 @@ An enum listing the types of User Action Detail Schemas for transfers in.
 [
 	`PIXUserAction`,
 	`IBANUserAction`,
-	`PSEUserAction`
+	`PSEUserAction`,
+	`URLUserAction`
 ]
 ```
 
@@ -2538,6 +2540,9 @@ The `iban` field represents the IBAN number for the provider-controlled bank acc
 
 #### 9.3.3.3. `PSEUserAction`
 
+**Deprecated:** Note that `PSEUserAction` is deprecated and its use is discouraged, in favor of the more general `URLUserAction` schema. Consider migrating
+existing implementations over to using this schema instead of `PSEUserAction`.
+
 `PSEUserAction` is a User Action Details Schema for transfers in requiring use of the Colombian [PSE payment system](https://www.pse.com.co/persona).
 
 ```
@@ -2548,6 +2553,21 @@ The `iban` field represents the IBAN number for the provider-controlled bank acc
 ```
 
 The `url` field contains a uniquely generated URL which the user can follow in order to complete their transfer of fiat funds to the provider using the PSE payment system.
+
+#### 9.3.3.4. `URLUserAction`
+
+`URLUserAction` is a User Action Details Schema for transfers in which require the user to follow a URL to complete the transfer of fiat funds. The URL itself, and
+action required by the user after navigating to the URL are unspecified by this schema; no particular semantics are required or imparted by use of the `URLUserAction`
+schema.
+
+```
+{
+	userActionType: `TransferInUserActionDetailsEnum.URLUserAction`,
+	url: `string`,
+}
+```
+
+The `url` field contains a URL which the user can follow in order to complete thier transfer of fiat funds to the provider.
 
 # 10. References
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "specification",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "FiatConnect API Specification",
   "repository": "https://github.com/fiatconnect/specification.git",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "specification",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "FiatConnect API Specification",
   "repository": "https://github.com/fiatconnect/specification.git",
   "scripts": {

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -104,9 +104,9 @@ definitions:
   UserActionTypeEnum:
     type: "string"
     enum: &UserActionTypeEnum
-      - PIX
-      - IBAN
-      - PSE
+      - PIXUserAction
+      - IBANUserAction
+      - PSEUserAction
   UserActionDetails:
     type: "object"
     properties:

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -107,11 +107,22 @@ definitions:
       - PIXUserAction
       - IBANUserAction
       - PSEUserAction
+      - URLUserAction
   UserActionDetails:
     type: "object"
+    required:
+      - userActionType
     properties:
       userActionType:
         $ref: '#/definitions/UserActionTypeEnum'
+      iban:
+        type: "string"
+      bic:
+        type: "string"
+      url:
+        type: "string"
+      pixString:
+        type: "string"
   QuoteRequest:
     type: "object"
     properties:


### PR DESCRIPTION
This PR adds in a new `URLUserAction` User Action Details Schema, which has the same schema as the existing `PSEUserAction` schema, but lacks the semantics of being explicitly for the PSE payment system. As a result, the `PSEUserAction` schema is being deprecated; it is still supported by the FiatConnect spec, but its use is discouraged.