### PR TITLE
feat(user-action-details): add AccountNumberUserAction

### DIFF
--- a/fiatconnect-api.md
+++ b/fiatconnect-api.md
@@ -246,7 +246,8 @@
       - [9.3.3.1. `PIXUserAction`](#9331-pixuseraction)
       - [9.3.3.2. `IBANUserAction`](#9332-ibanuseraction)
       - [9.3.3.3. `PSEUserAction`](#9333-pseuseraction)
-      - [9.3.3.4. `URLUserAction`](#9333-urluseraction)
+      - [9.3.3.4. `URLUserAction`](#9334-urluseraction)
+      - [9.3.3.5. `BankAccountTransferUserAction`](#9335-bankaccounttransferuseraction)
 - [10. References](#10-references)
   - [10.1. Normative References](#101-normative-references)
     - [10.1.1. [RFC2119]](#1011-rfc2119)
@@ -2568,6 +2569,25 @@ schema.
 ```
 
 The `url` field contains a URL which the user can follow in order to complete thier transfer of fiat funds to the provider.
+
+#### 9.3.3.5. `BankAccountTransferUserAction`
+
+`BankAccountTransferUserAction` is a User Action Details Schema for transfers in which require the user to send funds to 
+a bank account to complete the transfer of fiat funds. 
+
+```
+{
+	userActionType: `TransferInUserActionDetailsEnum.BankAccountTransferUserAction`,
+	bankName: `string`,
+	accountName: `string`,
+	accountNumber: `string`,
+	transactionReference: `string`,
+}
+```
+
+The `bankName`, `accountName`, and `accountNumber` fields describe a provider-controlled bank account that the user 
+should send funds to. The `transactionReference` field is a string that the user should include in the transaction 
+details when sending funds to the provider's bank account, for identification purposes.
 
 # 10. References
 

--- a/fiatconnect-api.md
+++ b/fiatconnect-api.md
@@ -247,7 +247,7 @@
       - [9.3.3.2. `IBANUserAction`](#9332-ibanuseraction)
       - [9.3.3.3. `PSEUserAction`](#9333-pseuseraction)
       - [9.3.3.4. `URLUserAction`](#9334-urluseraction)
-      - [9.3.3.5. `BankAccountTransferUserAction`](#9335-bankaccounttransferuseraction)
+      - [9.3.3.5. `AccountNumberUserAction`](#9335-AccountNumberUserAction)
 - [10. References](#10-references)
   - [10.1. Normative References](#101-normative-references)
     - [10.1.1. [RFC2119]](#1011-rfc2119)
@@ -2570,24 +2570,24 @@ schema.
 
 The `url` field contains a URL which the user can follow in order to complete thier transfer of fiat funds to the provider.
 
-#### 9.3.3.5. `BankAccountTransferUserAction`
+#### 9.3.3.5. `AccountNumberUserAction`
 
-`BankAccountTransferUserAction` is a User Action Details Schema for transfers in which require the user to send funds to 
-a bank account to complete the transfer of fiat funds. 
+`AccountNumberUserAction` is a User Action Details Schema for transfers in which require the user to send funds to 
+an account identified by some number to complete the transfer of fiat funds. 
 
 ```
 {
-	userActionType: `TransferInUserActionDetailsEnum.BankAccountTransferUserAction`,
-	bankName: `string`,
+	userActionType: `TransferInUserActionDetailsEnum.AccountNumberUserAction`,
+	institutionName: `string`,
 	accountName: `string`,
 	accountNumber: `string`,
 	transactionReference: `string`,
 }
 ```
 
-The `bankName`, `accountName`, and `accountNumber` fields describe a provider-controlled bank account that the user 
-should send funds to. The `transactionReference` field is a string that the user should include in the transaction 
-details when sending funds to the provider's bank account, for identification purposes.
+The `institutionName`, `accountName`, and `accountNumber` fields describe a provider-controlled 
+account that the user should send funds to. The `transactionReference` field is a string that the user MUST include 
+in the transaction details when sending funds to the provider's account, for identification purposes. 
 
 # 10. References
 

--- a/fiatconnect-api.md
+++ b/fiatconnect-api.md
@@ -2581,14 +2581,15 @@ an account identified by some number to complete the transfer of fiat funds.
 	institutionName: `string`,
 	accountName: `string`,
 	accountNumber: `string`,
-	transactionReference: `string`,
+	transactionReference?: `string`,
 	deadline?: `string`
 }
 ```
 
 The `institutionName`, `accountName`, and `accountNumber` fields describe a provider-controlled 
-account that the user should send funds to. The `transactionReference` field is a string that the user MUST include 
-in the transaction details when sending funds to the provider's account, for identification purposes. The `deadline` 
+account that the user should send funds to. The `transactionReference` field is a string that is intended to help providers 
+determine which FiatConnect transfer is associated with an incoming fiat transfer. If included, the user MUST include 
+the `transactionReference` string in the transaction details when sending funds to the provider's account. The `deadline` 
 field, if included, MUST be an ISO 8601 datetime string, and represents the time by which the user needs to send funds 
 to the provider's fiat account. If the user sends fiat funds after this time, the provider may choose whether to complete the 
 transfer or return the funds and mark the transfer as failed. 

--- a/fiatconnect-api.md
+++ b/fiatconnect-api.md
@@ -2582,12 +2582,16 @@ an account identified by some number to complete the transfer of fiat funds.
 	accountName: `string`,
 	accountNumber: `string`,
 	transactionReference: `string`,
+	deadline?: `string`
 }
 ```
 
 The `institutionName`, `accountName`, and `accountNumber` fields describe a provider-controlled 
 account that the user should send funds to. The `transactionReference` field is a string that the user MUST include 
-in the transaction details when sending funds to the provider's account, for identification purposes. 
+in the transaction details when sending funds to the provider's account, for identification purposes. The `deadline` 
+field, if included, MUST be an ISO 8601 datetime string, and represents the time by which the user needs to send funds 
+to the provider's fiat account. If the user sends fiat funds after this time, the provider may choose whether to complete the 
+transfer or return the funds and mark the transfer as failed. 
 
 # 10. References
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "specification",
-  "version": "1.1.5",
+  "version": "1.2.5",
   "description": "FiatConnect API Specification",
   "repository": "https://github.com/fiatconnect/specification.git",
   "scripts": {

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -108,6 +108,7 @@ definitions:
       - IBANUserAction
       - PSEUserAction
       - URLUserAction
+      - BankAccountTransferUserAction
   UserActionDetails:
     type: "object"
     required:
@@ -122,6 +123,14 @@ definitions:
       url:
         type: "string"
       pixString:
+        type: "string"
+      accountName:
+        type: "string"
+      accountNumber:
+        type: "string"
+      bankName:
+        type: "string"
+      transactionReference:
         type: "string"
   QuoteRequest:
     type: "object"

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -108,7 +108,7 @@ definitions:
       - IBANUserAction
       - PSEUserAction
       - URLUserAction
-      - BankAccountTransferUserAction
+      - AccountNumberUserAction
   UserActionDetails:
     type: "object"
     required:
@@ -128,7 +128,7 @@ definitions:
         type: "string"
       accountNumber:
         type: "string"
-      bankName:
+      institutionName:
         type: "string"
       transactionReference:
         type: "string"

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -132,6 +132,8 @@ definitions:
         type: "string"
       transactionReference:
         type: "string"
+      deadline:
+        type: "string"
   QuoteRequest:
     type: "object"
     properties:


### PR DESCRIPTION
We've seen FiatConnect providers use the URLUserActionDetails schema and direct users to their own website just to explain to them that they need to send funds to the same CICO provider's bank account. This defies the intention of the UserActionDetails feature, which is supposed to give FiatConnect clients a chance to explain to users what steps are needed to complete a transfer in-- not just hand them off to complete arbitrary steps on some other website. This PR adds a UserActionDetails schema that should bridge the gap, allowing CICO providers to solicit a bank transfer from end-users without redirecting them to another website. 